### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Integration level](https://dash.yunohost.org/integration/jitsi.svg)](https://dash.yunohost.org/appci/app/jitsi)  
 [![Install Jitsi Meet with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=jitsi)
 
-*[Lire ce readme en français.](./README_fr.md)*
-
 > *This package allow you to install Jitsi Meet quickly and simply on a YunoHost server.  
 If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to know how to install and enjoy it.*
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@
 [![Install Jitsi Meet with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=jitsi)
 
 > *This package allow you to install Jitsi Meet quickly and simply on a YunoHost server.  
-If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to know how to install and enjoy it.*
+[Install YunoHost](https://yunohost.org/#/install) to be able to do so.*
 
 ## Overview
-Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, secure and scalable video conferences.
+Jitsi Meet is a libre software (Apache) WebRTC JavaScript app that uses Jitsi Videobridge to provide high quality, secure, and scalable video conferences.
 
 **Shipped version:** 1.0.3387
 
-## Important points to read before installing
+## Important points before installing
 
-1. **Jitsi** require a dedicated **root domain**, eg. jitsi.domain.tld
-2. **Jitsi** require you create additionals domains in your dns and in your YunoHost
+1. **Jitsi** requires a dedicated **root domain**, eg. jitsi.domain.tld
+2. **Jitsi** requires you create additionals domains in your DNS and in your YunoHost
   * auth.jitsi.domain.tld
   * conference.jitsi.domain.tld
   * jitsi-videobridge.jitsi.domain.tld
   * focus.jitsi.domain.tld
-3. **Jitsi** require the ports TCP/4443 and UDP/10000 been redirected to your YunoHost
+3. **Jitsi** requires the ports TCP/4443 and UDP/10000 to be redirected to your YunoHost
 
 ## Screenshots
 
@@ -31,13 +31,13 @@ Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Ji
 
 ## Configuration
 
-How to configure this app: by an admin panel, a plain file with SSH, or any other way.
+How to configure this app: Via the admin panel, a plain file with SSH, or any other way.
 
 ## Documentation
 
  * Official documentation: https://jitsi.org/user-faq/
 
-## YunoHost specific features
+## Specific YunoHost features
 
 #### Supported architectures
 
@@ -54,12 +54,12 @@ How to configure this app: by an admin panel, a plain file with SSH, or any othe
 
 ---
 
-Developers info
+Developer info
 ----------------
 
-Please do your pull request to the [testing branch](https://github.com/YunoHost-Apps/jitsi_ynh/tree/testing).
+Please send your pull request to the [testing branch](https://github.com/YunoHost-Apps/jitsi_ynh/tree/testing).
 
-To try the testing branch, please proceed like that.
+To try the testing branch, do this:
 ```
 sudo yunohost app install https://github.com/YunoHost-Apps/jitsi_ynh/tree/testing --debug
 or

--- a/check_process
+++ b/check_process
@@ -14,6 +14,7 @@
 		setup_private=0
 		setup_public=1
 		upgrade=1
+		upgrade=1	from_commit=0ea33568698b64285207a9e3e9b5bd1f621e7826
 		backup_restore=1
 		multi_instance=0
 		# This test is no longer necessary since the version 2.7 (PR: https://github.com/YunoHost/yunohost/pull/304), you can still do it if your app could be installed with this version.
@@ -24,8 +25,8 @@
 	# If the level 5 (Package linter) is forced to 1. Please add justifications here.
 	Level 5=auto
 ;;; Options
-Email=
-Notification=none
+Email=yalh@yahoo.com
+Notification=all
 ;;; Upgrade options
 	; commit=CommitHash
 		name=Name and date of the commit.

--- a/conf/metronome.cfg.lua
+++ b/conf/metronome.cfg.lua
@@ -19,7 +19,7 @@
 -- for the server. Note that you must create the accounts separately
 -- (see http://prosody.im/doc/creating_accounts for info)
 -- Example: admins = { "user1@example.com", "user2@example.net" }
-admins = { "focus__APP__@auth.__DOMAIN__" }
+admins = { "svc__APP__focus@auth.__DOMAIN__" }
 daemonize = true
 cross_domain_bosh = true;
 component_ports = { __PORT_COMPONENT__ }

--- a/conf/metronome_regen_conf.hook
+++ b/conf/metronome_regen_conf.hook
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+force=${2:-0}  # 0/1 --force argument
+dryrun=${3:-0}  # 0/1 --dry-run argument
+pending_conf=$4 # Path of the pending conf file
+
+do_pre_regen() {
+  # Add specific domain metronome conf
+  cp -af "/usr/share/yunohost/templates/jitsi/." "${pending_conf}/../metronome/etc/metronome/conf.d/"
+}
+
+do_post_regen() {
+  regen_conf_files=$1
+}
+
+case "$1" in
+  pre)
+    do_pre_regen
+    ;;
+  post)
+    do_post_regen
+    ;;
+  *)
+    echo "Hook called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Video conferencing web application",
         "fr": "Application web de conférence vidéo"
     },
-    "version": "1.0.3387~ynh1",
+    "version": "1.0.3387~ynh2",
     "url": "https://jitsi.org/Projects/JitMeet",
     "license": "Apache-2.0",
     "maintainer": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,6 +11,11 @@ pkg_dependencies="openjdk-8-jdk openjdk-8-jre maven"
 # PERSONAL HELPERS
 #=================================================
 
+ynh_version_gt ()
+{
+    dpkg --compare-versions "$1" gt "$2"
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/backup
+++ b/scripts/backup
@@ -57,22 +57,31 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 # SPECIFIC BACKUP
 #=================================================
+# BACKUP METRONOME
+#=================================================
+ynh_print_info --message="Backing up Metronome..."
+
+# Backup Metronome domain conf template
+ynh_backup --src_path="/usr/share/yunohost/templates/jitsi/$domain.cfg.lua"
+ynh_backup --src_path="/usr/share/yunohost/templates/jitsi/auth.$domain.cfg.lua"
+ynh_backup --src_path="/usr/share/yunohost/templates/jitsi/conference.$domain.cfg.lua"
+ynh_backup --src_path="/usr/share/yunohost/templates/jitsi/jitsi-videobridge.$domain.cfg.lua"
+ynh_backup --src_path="/usr/share/yunohost/templates/jitsi/focus.$domain.cfg.lua"
+
+# Backup Metronome Hook
+ynh_backup --src_path="/usr/share/yunohost/hooks/conf_regen/50-metronome_$app"
+
+# Backup Metronome Module
+ynh_backup --src_path="/usr/lib/metronome/modules/mod_carbons.lua"
+ynh_backup --src_path="/usr/lib/metronome/modules/mod_http_altconnect.lua"
+ynh_backup --src_path="/usr/lib/metronome/modules/mod_smacks.lua"
+
+#=================================================
 # BACKUP LOGROTATE
 #=================================================
 ynh_print_info --message="Backing up logrotate configuration..."
 
 ynh_backup --src_path="/etc/logrotate.d/$app"
-
-#=================================================
-# BACKUP METRONOME CONFIG
-#=================================================
-ynh_print_info --message="Backing up Metronome configuration..."
-
-ynh_backup --src_path="/etc/metronome/conf.d/$domain.cfg.lua"
-
-ynh_backup --src_path="/usr/lib/metronome/modules/mod_carbons.lua"
-ynh_backup --src_path="/usr/lib/metronome/modules/mod_http_altconnect.lua"
-ynh_backup --src_path="/usr/lib/metronome/modules/mod_smacks.lua"
 
 #=================================================
 # BACKUP SYSTEMD

--- a/scripts/install
+++ b/scripts/install
@@ -130,6 +130,7 @@ ynh_print_info --message="Configuring metronome..."
 
 # Create additional domains
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+	ynh_print_info --message="Creating additional domains for package_check..."
 	yunohost domain add auth.$domain
 	yunohost domain add conference.$domain
 	yunohost domain add jitsi-videobridge.$domain
@@ -139,22 +140,26 @@ fi
 # Create focus user
 yunohost user create $focus_user -f $focus_user -l $focus_user -m ${focus_user}@auth.$domain -p $focus_password -q 0
 
-# Configure metronome
-mv /etc/metronome/conf.d/$domain.cfg.lua /etc/metronome/conf.d/$domain.cfg.lua.back
-mv /etc/metronome/conf.d/auth.$domain.cfg.lua /etc/metronome/conf.d/auth.$domain.cfg.lua.back
-mv /etc/metronome/conf.d/conference.$domain.cfg.lua /etc/metronome/conf.d/conference.$domain.cfg.lua.back
-mv /etc/metronome/conf.d/jitsi-videobridge.$domain.cfg.lua /etc/metronome/conf.d/jitsi-videobridge.$domain.cfg.lua.back
-mv /etc/metronome/conf.d/focus.$domain.cfg.lua /etc/metronome/conf.d/focus.$domain.cfg.lua.back
+# Add Metronome domain conf template
+metronome_conf="/usr/share/yunohost/templates/jitsi/$domain.cfg.lua"
+mkdir -p /usr/share/yunohost/templates/jitsi/
+cp ../conf/metronome.cfg.lua $metronome_conf
+ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$metronome_conf"
+ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$metronome_conf"
+ynh_replace_string --match_string="__VIDEOBRIDGE_SECRET__" --replace_string="$videobridge_secret" --target_file="$metronome_conf"
+ynh_replace_string --match_string="__FOCUS_SECRET__" --replace_string="$focus_secret" --target_file="$metronome_conf"
+ynh_replace_string --match_string="__PORT_COMPONENT__" --replace_string="$port_component" --target_file="$metronome_conf"
 
-metronome="/etc/metronome/conf.d/$domain.cfg.lua"
-cp ../conf/metronome.cfg.lua "$metronome"
-ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$metronome"
-ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$metronome"
-ynh_replace_string --match_string="__VIDEOBRIDGE_SECRET__" --replace_string="$videobridge_secret" --target_file="$metronome"
-ynh_replace_string --match_string="__FOCUS_SECRET__" --replace_string="$focus_secret" --target_file="$metronome"
-ynh_replace_string --match_string="__PORT_COMPONENT__" --replace_string="$port_component" --target_file="$metronome"
-chown -R metronome:metronome "/etc/metronome/conf.d/"
+touch "/usr/share/yunohost/templates/jitsi/auth.$domain.cfg.lua"
+touch "/usr/share/yunohost/templates/jitsi/conference.$domain.cfg.lua"
+touch "/usr/share/yunohost/templates/jitsi/jitsi-videobridge.$domain.cfg.lua"
+touch "/usr/share/yunohost/templates/jitsi/focus.$domain.cfg.lua"
 
+# Add Metronome hook 
+cp -R ../conf/metronome_regen_conf.hook /usr/share/yunohost/hooks/conf_regen/50-metronome_$app
+yunohost tools regen-conf metronome
+
+# Add Metronome modules
 cp ../conf/mod_carbons.lua /usr/lib/metronome/modules/mod_carbons.lua
 cp ../conf/mod_http_altconnect.lua /usr/lib/metronome/modules/mod_http_altconnect.lua
 cp ../conf/mod_smacks.lua /usr/lib/metronome/modules/mod_smacks.lua

--- a/scripts/remove
+++ b/scripts/remove
@@ -114,18 +114,28 @@ fi
 #=================================================
 ynh_print_info --message="Reconfiguring Metronome..."
 
-# Reconfigure metronome
-mv -f /etc/metronome/conf.d/$domain.cfg.lua.back /etc/metronome/conf.d/$domain.cfg.lua
-mv /etc/metronome/conf.d/auth.$domain.cfg.lua.back /etc/metronome/conf.d/auth.$domain.cfg.lua
-mv /etc/metronome/conf.d/conference.$domain.cfg.lua.back /etc/metronome/conf.d/conference.$domain.cfg.lua
-mv /etc/metronome/conf.d/jitsi-videobridge.$domain.cfg.lua.back /etc/metronome/conf.d/jitsi-videobridge.$domain.cfg.lua
-mv /etc/metronome/conf.d/focus.$domain.cfg.lua.back /etc/metronome/conf.d/focus.$domain.cfg.lua
-
+# Remove Metronome modules
 ynh_secure_remove --file="/usr/lib/metronome/modules/mod_carbons.lua"
 ynh_secure_remove --file="/usr/lib/metronome/modules/mod_http_altconnect.lua"
 ynh_secure_remove --file="/usr/lib/metronome/modules/mod_smacks.lua"
 
 ynh_systemd_action --service_name=metronome --action=restart
+
+# Remove domain conf template
+ynh_secure_remove --file="/usr/share/yunohost/templates/jitsi/$domain.cfg.lua"
+ynh_secure_remove --file="/usr/share/yunohost/templates/jitsi/auth.$domain.cfg.lua"
+ynh_secure_remove --file="/usr/share/yunohost/templates/jitsi/conference.$domain.cfg.lua"
+ynh_secure_remove --file="/usr/share/yunohost/templates/jitsi/jitsi-videobridge.$domain.cfg.lua"
+ynh_secure_remove --file="/usr/share/yunohost/templates/jitsi/focus.$domain.cfg.lua"
+
+# Remove Jitsi template directory
+if [ -z "$(ls -A /usr/share/yunohost/templates/jitsi)" ]; then
+   ynh_secure_remove --file="/usr/share/yunohost/templates/jitsi"
+fi
+
+# Remove Metronome Hook
+ynh_secure_remove --file="/usr/share/yunohost/hooks/conf_regen/50-metronome_$app"
+yunohost tools regen-conf metronome
 
 # Delete focus user
 yunohost user delete $focus_user --purge

--- a/scripts/restore
+++ b/scripts/restore
@@ -116,16 +116,19 @@ fi
 # Create focus user
 yunohost user create $focus_user -f $focus_user -l $focus_user -m ${focus_user}@auth.$domain -p $focus_password -q 0
 
-# Configure metronome
-mv /etc/metronome/conf.d/$domain.cfg.lua /etc/metronome/conf.d/$domain.cfg.lua.back
-mv /etc/metronome/conf.d/auth.$domain.cfg.lua /etc/metronome/conf.d/auth.$domain.cfg.lua.back
-mv /etc/metronome/conf.d/conference.$domain.cfg.lua /etc/metronome/conf.d/conference.$domain.cfg.lua.back
-mv /etc/metronome/conf.d/jitsi-videobridge.$domain.cfg.lua /etc/metronome/conf.d/jitsi-videobridge.$domain.cfg.lua.back
-mv /etc/metronome/conf.d/focus.$domain.cfg.lua /etc/metronome/conf.d/focus.$domain.cfg.lua.back
+# Restore Metronome domain conf template
+mkdir -p /usr/share/yunohost/templates/jitsi/
+ynh_restore_file --origin_path="/usr/share/yunohost/templates/jitsi/$domain.cfg.lua"
+ynh_restore_file --origin_path="/usr/share/yunohost/templates/jitsi/auth.$domain.cfg.lua"
+ynh_restore_file --origin_path="/usr/share/yunohost/templates/jitsi/conference.$domain.cfg.lua"
+ynh_restore_file --origin_path="/usr/share/yunohost/templates/jitsi/jitsi-videobridge.$domain.cfg.lua"
+ynh_restore_file --origin_path="/usr/share/yunohost/templates/jitsi/focus.$domain.cfg.lua"
 
-ynh_restore_file --origin_path="/etc/metronome/conf.d/$domain.cfg.lua"
-chown -R metronome:metronome "/etc/metronome/conf.d/"
+# Restore Metronome Hook
+ynh_restore_file --origin_path="/usr/share/yunohost/hooks/conf_regen/50-metronome_$app"
+yunohost tools regen-conf metronome
 
+# Restore Metronome modules
 ynh_restore_file --origin_path="/usr/lib/metronome/modules/mod_carbons.lua"
 ynh_restore_file --origin_path="/usr/lib/metronome/modules/mod_http_altconnect.lua"
 ynh_restore_file --origin_path="/usr/lib/metronome/modules/mod_smacks.lua"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,6 +32,7 @@ focus_password=$(ynh_app_setting_get --app=$app --key=focus_password)
 #=================================================
 
 upgrade_type=$(ynh_check_app_version_changed)
+current_version=$(ynh_read_manifest --manifest="/etc/yunohost/apps/$app/manifest.json" --manifest_key="version" || echo 1.0)
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -42,6 +43,27 @@ ynh_print_info --message="Ensuring downward compatibility..."
 if [ -z "$final_path" ]; then
 	final_path=/var/www/$app
 	ynh_app_setting_set --app=$app --key=final_path --value=$final_path
+fi
+
+if ynh_version_gt "1.0.3387~ynh2" "${current_version}" ; then
+    # Add Metronome domain conf template
+    metronome_conf="/usr/share/yunohost/templates/jitsi/$domain.cfg.lua"
+    mkdir -p /usr/share/yunohost/templates/jitsi/
+    cp ../conf/metronome.cfg.lua $metronome_conf
+    ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$metronome_conf"
+    ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$metronome_conf"
+    ynh_replace_string --match_string="__VIDEOBRIDGE_SECRET__" --replace_string="$videobridge_secret" --target_file="$metronome_conf"
+    ynh_replace_string --match_string="__FOCUS_SECRET__" --replace_string="$focus_secret" --target_file="$metronome_conf"
+    ynh_replace_string --match_string="__PORT_COMPONENT__" --replace_string="$port_component" --target_file="$metronome_conf"
+
+    touch "/usr/share/yunohost/templates/jitsi/auth.$domain.cfg.lua"
+    touch "/usr/share/yunohost/templates/jitsi/conference.$domain.cfg.lua"
+    touch "/usr/share/yunohost/templates/jitsi/jitsi-videobridge.$domain.cfg.lua"
+    touch "/usr/share/yunohost/templates/jitsi/focus.$domain.cfg.lua"
+
+    # Add Metronome hook 
+    cp -R ../conf/metronome_regen_conf.hook /usr/share/yunohost/hooks/conf_regen/50-metronome_$app
+    yunohost tools regen-conf metronome
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem
- *In case of `yunohost tools regen-conf --force`, metronome specific config is trashed*

## Solution
- *Adding hook for metronome regen*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/jitsi_ynh%20PR14%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/jitsi_ynh%20PR14%20(yalh76)/)  
