### PR TITLE
[enh] add note about needing 4 subdomains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,11 @@
                     "en": "Choose a domain for Jitsi Meet",
                     "fr": "Choisissez un domaine pour Jitsi Meet"
                 },
-                "example": "domain.org"
+                "example": "domain.org",
+                "help": {
+                    "en": "In addition to this domain, you need to have created beforehand 4 subdomains of this domain: auth.jitsi.domain.org, conference.jitsi.domain.org, jitsi-videobridge.jitsi.domain.org, focus.jitsi.domain.org",
+                    "fr": "En plus de ce domaine, vous devez avoir préalablement créé 4 sous-domaines de ce domaine : auth.jitsi.domain.org, conference.jitsi.domain.org, jitsi-videobridge.jitsi.domain.org, focus.jitsi.domain.org"
+                }
             }
         ]
     }


### PR DESCRIPTION
## Problem
- [Users are complaining](https://forum.yunohost.org/t/indiquer-aux-admins-quil-faut-ajouter-des-domaines-pour-installer-jitsi-meet/10912) about not knowing about the 4 subdomains needed. GitHub instructions are somewhat not obvious to newcomers.

## Solution
- Add a `help` key in the manifest.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check : N/A
- [ ] Fix or enhancement tested : N/A
- [ ] Upgrade from last version tested : N/A
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/jitsi_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/jitsi_ynh%20PR-NUM-%20(USERNAME)/)  
