### PR TITLE
add max memory for vm configuration (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Jitsi Meet is a libre software (Apache) WebRTC JavaScript app that uses Jitsi Vi
 2. **Jitsi** requires the ports TCP/4443 and UDP/10000 to be forwarded to your YunoHost (The same way you forwarded 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
 3. **Jitsi** will stop and disable Metronome XMPP.
 4. LDAP authentication is activated, only authenticated users to create new conference rooms. Whenever a new room is about to be created, Jitsi Meet will prompt for a user name and password. After the room is created, others will be able to join from anonymous domain.
+5. **Jitsi** is configured for 50 users maximum, this number can be increase going to the Yunohost config panel
 
 ## Documentation and resources
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -30,6 +30,7 @@ Jitsi Meet est un logiciel libre (Apache) dont Jitsi Videobridge, avec WebRTC Ja
 2. **Jitsi** demande que les ports TCP/4443 et UDP/10000 soient routés vers votre YunoHost (De la même manière que le sont les ports 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
 3. **Jitsi** va arréter et désactiver le service XMPP Metronome.
 4. L'authentification LDAP est activée, seuls les utilisateurs authentifiés peuvent créer de nouvelles salles de conférence. Chaque fois qu'une nouvelle salle est sur le point d'être créée, Jitsi Meet vous demandera un nom d'utilisateur et un mot de passe. Une fois la salle créée, d'autres personnes pourront la rejoindre à partir d'un domaine anonyme. 
+5. **Jitsi** est configuré pour 50 utilisateurs maximum, ce nombre peut être augmenté en allant dans le panneau de configuration Yunohost
 
 ## Documentations et ressources
 

--- a/conf/jitsi-jicofo-config
+++ b/conf/jitsi-jicofo-config
@@ -17,5 +17,8 @@ JICOFO_AUTH_PASSWORD=__FOCUS_PASSWORD__
 # extra options to pass to the jicofo daemon
 JICOFO_OPTS=""
 
+# set the max memory used during VM alocation
+JICOFO_MAX_MEMORY=__MAX_MEMORY__m
+
 # adds java system props that are passed to jicofo (default are for home and logging config file)
 JAVA_SYS_PROPS="-Dconfig.file=/etc/__APP__/jicofo/jicofo.conf -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/__APP__ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=jicofo -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/__APP__ -Djava.util.logging.config.file=/etc/__APP__/jicofo/logging.properties"

--- a/conf/jitsi-videobridge.config
+++ b/conf/jitsi-videobridge.config
@@ -12,5 +12,8 @@ JVB_PORT=__PORT_COMPONENT__
 # sets the shared secret used to authenticate to the XMPP server
 JVB_SECRET=__VIDEOBRIDGE_SECRET__
 
+# add max memory used during VM alocation
+VIDEOBRIDGE_MAX_MEMORY=__MAX_MEMORY__m
+
 # adds java system props that are passed to jvb (default are for home and logging config file)
 JAVA_SYS_PROPS="-Dconfig.file=/etc/__APP__/videobridge/jvb.conf -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/__APP__ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/__APP__ -Djava.util.logging.config.file=/etc/__APP__/videobridge/logging.properties"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,14 @@
+version = "1.0"
+
+[main]
+name = "Main configuration"
+services = ["__APP__-jicofo","__APP__-videobridge"]
+
+    [main.config]
+    name = "Global configurations"
+
+        [main.config.max_memory]
+        bind = "null"
+        ask.en = "Max memory to use for VM"
+        type = "number"
+        help = "One user consume about 1,5 Mib memory, for example if plan to have max 50 simultaneous users this parameter should be set to 75 mb"

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -4,3 +4,4 @@
 2. **Jitsi** requires the ports TCP/4443 and UDP/10000 to be forwarded to your YunoHost (The same way you forwarded 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
 3. **Jitsi** will stop and disable Metronome XMPP.
 4. LDAP authentication is activated, only authenticated users to create new conference rooms. Whenever a new room is about to be created, Jitsi Meet will prompt for a user name and password. After the room is created, others will be able to join from anonymous domain.
+5. **Jitsi** is configured for 50 users maximum, this number can be increase going to the Yunohost config panel

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -4,3 +4,4 @@
 2. **Jitsi** demande que les ports TCP/4443 et UDP/10000 soient routés vers votre YunoHost (De la même manière que le sont les ports 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
 3. **Jitsi** va arréter et désactiver le service XMPP Metronome.
 4. L'authentification LDAP est activée, seuls les utilisateurs authentifiés peuvent créer de nouvelles salles de conférence. Chaque fois qu'une nouvelle salle est sur le point d'être créée, Jitsi Meet vous demandera un nom d'utilisateur et un mot de passe. Une fois la salle créée, d'autres personnes pourront la rejoindre à partir d'un domaine anonyme. 
+5. **Jitsi** est configuré pour 50 utilisateurs maximum, ce nombre peut être augmenté en allant dans le panneau de configuration Yunohost

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source _common.sh
+source /usr/share/yunohost/helpers
+
+ynh_abort_if_errors
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+
+#=================================================
+# SPECIFIC GETTERS FOR TOML SHORT KEY
+#=================================================
+
+get__max_memory(){
+  local max_memory=$(ynh_app_setting_get --app=$app --key=max_memory)
+  
+  # If max_memory doesn't exist, create it and set to default 75 mb value
+  if [ -z "$max_memory" ]; then
+    max_memory=75
+    ynh_app_setting_set --app=$app --key=max_memory --value=$max_memory
+  fi
+	
+  cat << EOF
+value: $max_memory
+EOF
+}
+
+#=================================================
+# SPECIFIC VALIDATORS FOR TOML SHORT KEYS
+#=================================================
+
+#=================================================
+# SPECIFIC SETTERS FOR TOML SHORT KEYS
+#=================================================
+
+set__max_memory(){
+
+  #=================================================
+  # LOAD SETTINGS
+  #=================================================
+
+  ynh_script_progression --message="Loading installation settings..."
+
+  domain=$(ynh_app_setting_get --app=$app --key=domain)
+  path_url=$(ynh_app_setting_get --app=$app --key=path)
+  final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+
+  focus_user=$(ynh_app_setting_get --app=$app --key=focus_user)
+  focus_password=$(ynh_app_setting_get --app=$app --key=focus_password)
+  focus_secret=$(ynh_app_setting_get --app=$app --key=focus_secret)
+
+  videobridge_user=$(ynh_app_setting_get --app=$app --key=videobridge_user)
+  videobridge_secret=$(ynh_app_setting_get --app=$app --key=videobridge_secret)
+
+  port=$(ynh_app_setting_get --app=$app --key=port)
+  port_videobridge=$(ynh_app_setting_get --app=$app --key=port_videobridge)
+  port_component=$(ynh_app_setting_get --app=$app --key=port_component)
+
+  #=================================================
+  # SET SETTINGS
+  #=================================================
+  
+  ynh_app_setting_set --app=$app --key=max_memory --value=$max_memory
+  
+  #=================================================
+  # UPDATE CONFIG FILES
+  #=================================================
+  
+  ynh_add_config --template="../conf/jitsi-videobridge.config" --destination="/etc/$app/videobridge/config"
+  ynh_add_config --template="../conf/jitsi-jicofo-config" --destination="/etc/$app/jicofo/config"
+  
+  ynh_script_progression -l --message="Configuration of $app updated"
+}
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+
+ynh_app_config_run $1

--- a/scripts/install
+++ b/scripts/install
@@ -42,6 +42,8 @@ focus_user="focus"
 
 videobridge_user="jvb"
 
+max_memory=75
+
 #=================================================
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
 #=================================================
@@ -60,6 +62,7 @@ ynh_script_progression --message="Storing installation settings..."
 
 ynh_app_setting_set --app=$app --key=domain --value=$domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
+ynh_app_setting_set --app=$app --key=max_memory --value=$max_memory
 ynh_app_setting_set --app=$app --key=focus_user --value=$focus_user
 ynh_app_setting_set --app=$app --key=focus_password --value=$focus_password
 ynh_app_setting_set --app=$app --key=focus_secret --value=$focus_secret

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,6 +20,8 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
+max_memory=$(ynh_app_setting_get --app=$app --key=max_memory)
+
 focus_user=$(ynh_app_setting_get --app=$app --key=focus_user)
 focus_password=$(ynh_app_setting_get --app=$app --key=focus_password)
 focus_secret=$(ynh_app_setting_get --app=$app --key=focus_secret)
@@ -76,6 +78,12 @@ ynh_script_progression --message="Ensuring downward compatibility..."
 if [ -z "$final_path" ]; then
 	final_path=/var/www/$app
 	ynh_app_setting_set --app=$app --key=final_path --value=$final_path
+fi
+
+# If max_memory doesn't exist, create it and set to default 75 mb value
+if [ -z "$max_memory" ]; then
+	max_memory=75
+	ynh_app_setting_set --app=$app --key=max_memory --value=$max_memory
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

on small memory SBC default java VM memory alocation is too much "3072mb" 
this result in jvb and jicofo fails to start

## Solution

set VIDEOBRIDGE_MAX_MEMORY and JICOFO_MAX_MEMORY in respective config file depends on estimated max user using bridge at a time
