### PR TITLE
[autopatch] Add Common Platform Enumeration id to manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Jitsi Meet is a libre software (Apache) WebRTC JavaScript app that uses Jitsi Videobridge to provide high quality, secure, and scalable video conferences.
 
 
-**Shipped version:** 1.0.6155~ynh1
+**Shipped version:** 1.0.6155~ynh2
 
 **Demo:** https://meet.jit.si/
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Jitsi Meet is a libre software (Apache) WebRTC JavaScript app that uses Jitsi Vi
 
 **Shipped version:** 1.0.6155~ynh2
 
+
 **Demo:** https://meet.jit.si/
 
 ## Screenshots

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,8 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Jitsi Meet est un logiciel libre (Apache) dont Jitsi Videobridge, avec WebRTC Javascript, propose des vidéos-conférences de haute qualité, sécurisées et évolutives.
 
 
-**Version incluse :** 1.0.6155~ynh2
+**Version incluse :** 1.0.6155~ynh2
+
 
 **Démo :** https://meet.jit.si/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Jitsi Meet est un logiciel libre (Apache) dont Jitsi Videobridge, avec WebRTC Javascript, propose des vidéos-conférences de haute qualité, sécurisées et évolutives.
 
 
-**Version incluse :** 1.0.6155~ynh1
+**Version incluse :** 1.0.6155~ynh2
 
 **Démo :** https://meet.jit.si/
 

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
         "website": "https://jitsi.org/",
         "demo": "https://meet.jit.si/",
         "userdoc": "https://jitsi.org/user-faq/",
-        "code": "https://github.com/jitsi/jitsi-meet"
+        "code": "https://github.com/jitsi/jitsi-meet",
+        "cpe": "cpe:2.3:a:jitsi:jitsi"
     },
     "license": "Apache-2.0",
     "maintainer": {
@@ -21,8 +22,8 @@
     },
     "previous_maintainers": [
         {
-        "name": "ju",
-        "email": "julien.malik@paraiso.me"
+            "name": "ju",
+            "email": "julien.malik@paraiso.me"
         }
     ],
     "requirements": {


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to add the (optional but recommended if relevant) Common Platform Enumeration (CPE) id, which is sort of a standard id for applications, defined by the NIST.

In particular, Yunohost may use this is in the future to easily track CVE (=security reports) related to apps.

The CPE may be obtained by searching here: https://nvd.nist.gov/products/cpe/search. For example, for Nextcloud, the CPE is 'cpe:2.3:a:nextcloud:nextcloud' (no need to include the version number)").