### PR TITLE
remove metronome before starting the install

### DIFF
--- a/doc/PRE_INSTALL.md
+++ b/doc/PRE_INSTALL.md
@@ -2,6 +2,6 @@
 
 1. **Jitsi** requires a dedicated **root domain**, eg. jitsi.domain.tld
 2. **Jitsi** requires the ports TCP/4443 and UDP/10000 to be forwarded to your YunoHost (The same way you forwarded 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
-3. **Jitsi** will stop and disable Metronome XMPP.
+3. You must first uninstall the Metronome XMPP service: `sudo apt remove metronome`
 4. LDAP authentication is activated, only authenticated users to create new conference rooms. Whenever a new room is about to be created, Jitsi Meet will prompt for a user name and password. After the room is created, others will be able to join from anonymous domain.
 5. **Jitsi** is configured for 50 users maximum, this number can be increased in the Yunohost config panel

--- a/doc/PRE_INSTALL_fr.md
+++ b/doc/PRE_INSTALL_fr.md
@@ -2,6 +2,6 @@
 
 1. **Jitsi** a besoin d'un **domaine racine** dédié, par exemple : jitsi.domain.tld
 2. **Jitsi** demande que les ports TCP/4443 et UDP/10000 soient routés vers votre YunoHost (De la même manière que le sont les ports 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
-3. **Jitsi** va arréter et désactiver le service XMPP Metronome.
+3. Vous devez au préalable désinstaller le service XMPP Metronome : `sudo apt remove metronome`
 4. L'authentification LDAP est activée, seuls les utilisateurs authentifiés peuvent créer de nouvelles salles de conférence. Chaque fois qu'une nouvelle salle est sur le point d'être créée, Jitsi Meet vous demandera un nom d'utilisateur et un mot de passe. Une fois la salle créée, d'autres personnes pourront la rejoindre à partir d'un domaine anonyme. 
 5. **Jitsi** est configuré pour 50 utilisateurs maximum, ce nombre peut être augmenté en allant dans le panneau de configuration Yunohost


### PR DESCRIPTION
## Problem

- the package can’t remove metronome by itself since the core handles dependancies first at the start f the install process

## Solution

- Ask users to remove metronome before the installation

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
