### PR TITLE
Testing v2.0.9164~ynh2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Jitsi Meet is a libre software (Apache) WebRTC JavaScript app that uses Jitsi Videobridge to provide high quality, secure, and scalable video conferences.
 
 
-**Shipped version:** 2.0.9164~ynh1
+**Shipped version:** 2.0.9164~ynh2
 
 **Demo:** https://meet.jit.si/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Jitsi Meet est un logiciel libre (Apache) dont Jitsi Videobridge, avec WebRTC Javascript, propose des vidéos-conférences de haute qualité, sécurisées et évolutives.
 
 
-**Version incluse :** 2.0.9164~ynh1
+**Version incluse :** 2.0.9164~ynh2
 
 **Démo :** https://meet.jit.si/
 

--- a/conf/jitsi-meet-config.js
+++ b/conf/jitsi-meet-config.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars, no-var */
 
+var enableJaaS = false;
+
 var config = {
     // Connection
     //

--- a/doc/PRE_INSTALL.md
+++ b/doc/PRE_INSTALL.md
@@ -2,6 +2,6 @@
 
 1. **Jitsi** requires a dedicated **root domain**, eg. jitsi.domain.tld
 2. **Jitsi** requires the ports TCP/4443 and UDP/10000 to be forwarded to your YunoHost (The same way you forwarded 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
-3. **Jitsi** will stop and disable Metronome XMPP.
+3. You must first uninstall the Metronome XMPP service: `sudo apt remove metronome`
 4. LDAP authentication is activated, only authenticated users to create new conference rooms. Whenever a new room is about to be created, Jitsi Meet will prompt for a user name and password. After the room is created, others will be able to join from anonymous domain.
 5. **Jitsi** is configured for 50 users maximum, this number can be increased in the Yunohost config panel

--- a/doc/PRE_INSTALL_fr.md
+++ b/doc/PRE_INSTALL_fr.md
@@ -2,6 +2,6 @@
 
 1. **Jitsi** a besoin d'un **domaine racine** dédié, par exemple : jitsi.domain.tld
 2. **Jitsi** demande que les ports TCP/4443 et UDP/10000 soient routés vers votre YunoHost (De la même manière que le sont les ports 80 (HTTP), 443 (HTTPS), etc... https://yunohost.org/#/isp_box_config)
-3. **Jitsi** va arréter et désactiver le service XMPP Metronome.
+3. Vous devez au préalable désinstaller le service XMPP Metronome : `sudo apt remove metronome`
 4. L'authentification LDAP est activée, seuls les utilisateurs authentifiés peuvent créer de nouvelles salles de conférence. Chaque fois qu'une nouvelle salle est sur le point d'être créée, Jitsi Meet vous demandera un nom d'utilisateur et un mot de passe. Une fois la salle créée, d'autres personnes pourront la rejoindre à partir d'un domaine anonyme. 
 5. **Jitsi** est configuré pour 50 utilisateurs maximum, ce nombre peut être augmenté en allant dans le panneau de configuration Yunohost

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jitsi Meet"
 description.en = "Video conferencing web application"
 description.fr = "Application web de conférence vidéo"
 
-version = "2.0.9164~ynh1"
+version = "2.0.9164~ynh2"
 
 maintainers = ["yalh76"]
 

--- a/tests.toml
+++ b/tests.toml
@@ -2,6 +2,8 @@
 
 test_format = 1.0
 
+exclude = "change_url"
+
 [default]
 
     # ------------


### PR DESCRIPTION
#135 
#137 
Also [disable change_url CI test](https://github.com/YunoHost-Apps/jitsi_ynh/pull/138/commits/456c4e898bf3960d772731aa7c79887a197ade48) because the package doesn’t supports it and this unfortunately maintain the app at level 6 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
