### PR TITLE
remove mod_auth_ldap reference

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -77,14 +77,6 @@ ram.runtime = "50M"
     extract = false
     rename = "jitsi-meet-prosody.deb"
 
-    [resources.sources.mod_auth_ldap]
-    url = "https://hg.prosody.im/prosody-modules/raw-file/tip/mod_auth_ldap/mod_auth_ldap.lua"
-    sha256 = "49c67ec86ec75ac8de93803be2ac7f907d1e9d3d22cd4c88fd48aaeed7a411e3"
-    format = "whatever"
-    extract = false
-    rename = "mod_auth_ldap.lua"
-
-
     [resources.system_user]
 
     [resources.install_dir]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -24,8 +24,6 @@ _setup_sources() {
         mv "$install_dir/temp/usr/share/${packages[$package]}/" "$install_dir/$package/"
         ynh_safe_rm "$install_dir/temp"
     done
-
-    ynh_setup_source --dest_dir="$install_dir/jitsi-meet-prosody" --source_id=mod_auth_ldap
 }
 
 ynh_jniwrapper_armhf () {


### PR DESCRIPTION
## Problem

- #185: "This module is [included with Prosody][doc:modules:mod_auth_ldap] since version 0.12.0."

## Solution

- remove explicit sources from manifest and _common

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)