### PR TITLE
comment out test_upgrade

### DIFF
--- a/tests.toml
+++ b/tests.toml
@@ -13,4 +13,4 @@ test_format = 1.0
     #test_upgrade_from.12d4758e.name = "1.0.5913~ynh1"
     #test_upgrade_from.afbc84d3.name = "1.0.5913~ynh3"
     #test_upgrade_from.4a043dfd.name = "2.0.8719~ynh2"
-    test_upgrade_from.f135089e02beb2b2a992a4db39b0823b0ac0fdf0.name = "2.0.9753~ynh2"
+    #test_upgrade_from.f135089e02beb2b2a992a4db39b0823b0ac0fdf0.name = "2.0.9753~ynh2"


### PR DESCRIPTION
## Problem

- previous versions cannot be successfully installed, due to `mod_auth_ldap` having been taken down by upstream devs 

## Solution

- comment out `test_upgrade_from.f135089e02beb2b2a992a4db39b0823b0ac0fdf0.name = "2.0.9753~ynh2"` from `tests.toml`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)