### PR TITLE
switch polls to component

### DIFF
--- a/conf/prosody.cfg.lua
+++ b/conf/prosody.cfg.lua
@@ -76,7 +76,6 @@ Component "conference.__DOMAIN__" "muc"
     modules_enabled = {
         "muc_meeting_id";
         "muc_domain_mapper";
-        "polls";
         --"token_verification";
         "muc_rate_limit";
     }
@@ -137,5 +136,6 @@ Component "lobby.__DOMAIN__" "muc"
     muc_room_default_public_jids = true
     modules_enabled = {
         "muc_rate_limit";
-        "polls";
     }
+
+Component "polls.__DOMAIN__" "polls_component"


### PR DESCRIPTION
## Problem

- polls no longer work

## Solution

- switch to using polls as a component, as per [upstream](https://github.com/jitsi/jitsi-meet/pull/16406/changes#diff-2b7efd61d232582a5f40cd2b9d8721169f6a285f61d3cdfc9e7bab65487e3519)
 
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
