### PR TITLE
Allocate ports for jvb and jicofo

### DIFF
--- a/conf/jitsi-jicofo-jicofo.conf
+++ b/conf/jitsi-jicofo-jicofo.conf
@@ -21,4 +21,7 @@ jicofo {
   bridge: {
     brewery-jid: "JvbBrewery@internal.auth.__DOMAIN__"
   }
+  rest: {
+    port: __PORT_JICOFO__
+  }
 }

--- a/conf/jitsi-videobridge-jvb.conf
+++ b/conf/jitsi-videobridge-jvb.conf
@@ -1,7 +1,12 @@
 videobridge {
+    apis {
+        rest {
+            enabled = true
+        }
+    }
     http-servers {
         public {
-            port = 9090
+            port = __PORT_JVB__
         }
     }
     websockets {

--- a/manifest.toml
+++ b/manifest.toml
@@ -90,6 +90,8 @@ ram.runtime = "50M"
     videobridge.default = 10000
     videobridge.exposed = "UDP"
     component.default = 5347
+    jvb.default = 9090
+    jicofo.default = 8888
 
     [resources.apt]
     packages = [

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -80,7 +80,7 @@ ynh_script_progression "configuring Jitsi-Jicofo..."
 
 ynh_config_add --template="jitsi-jicofo-config" --destination="/etc/$app/jicofo/config"
 ynh_config_add --template="jitsi-jicofo-jicofo.conf" --destination="/etc/$app/jicofo/jicofo.conf"
-
+ynh_config_add --template="jitsi-videobridge-jvb.conf" --destination="/etc/$app/videobridge/jvb.conf"
 ynh_config_add --template="jitsi-jicofo-logging.properties" --destination="/etc/$app/jicofo/logging.properties"
 
 #=================================================
@@ -119,7 +119,6 @@ ynh_config_add_logrotate
 ynh_script_progression "Starting $app's systemd service..."
 
 ynh_systemctl --service="$app-jicofo" --action="start" --log_path="/var/log/$app/$app-jicofo.log"
-ynh_config_add --template="jitsi-videobridge-jvb.conf" --destination="/etc/$app/videobridge/jvb.conf"
 ynh_systemctl --service="$app-videobridge" --action="start" --log_path="/var/log/$app/$app-videobridge.log"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -80,6 +80,7 @@ ynh_script_progression "configuring Jitsi-Jicofo..."
 
 ynh_config_add --template="jitsi-jicofo-config" --destination="/etc/$app/jicofo/config"
 ynh_config_add --template="jitsi-jicofo-jicofo.conf" --destination="/etc/$app/jicofo/jicofo.conf"
+
 ynh_config_add --template="jitsi-jicofo-logging.properties" --destination="/etc/$app/jicofo/logging.properties"
 
 #=================================================
@@ -118,6 +119,7 @@ ynh_config_add_logrotate
 ynh_script_progression "Starting $app's systemd service..."
 
 ynh_systemctl --service="$app-jicofo" --action="start" --log_path="/var/log/$app/$app-jicofo.log"
+ynh_config_add --template="jitsi-videobridge-jvb.conf" --destination="/etc/$app/videobridge/jvb.conf"
 ynh_systemctl --service="$app-videobridge" --action="start" --log_path="/var/log/$app/$app-videobridge.log"
 
 #=================================================


### PR DESCRIPTION
Allocate free ports instead of default values to prevent conflicts with other apps
    jvb_pub.default = 9090 (headscale...)
    jicofo.default = 8888 (seaweedfs...)
/!\ only tested on two instances